### PR TITLE
Add accessibility test for timetable

### DIFF
--- a/test/timetable_accessibility_test.dart
+++ b/test/timetable_accessibility_test.dart
@@ -1,0 +1,135 @@
+import 'accessibility/widgets/material.dart';
+import 'accessibility/components/list.dart';
+import 'accessibility/components/text.dart';
+
+// Include necessary tests and mocks
+import 'testing/gtest/gles.dart';
+import 'testing/event/keyboard/navigations.dart';
+import 'esting, keyboard nav, AAC.
+import 'dtype/dynamic.dart';
+import 'types/dictionary.dart';
+
+class TimetableAccessTest extends StatelessWidget {
+  const TestMatrixTimetable = MatrixTimetable(label: 'Time Table');
+  const TestPlaceTitles = PlaceTitles(label: 'Title');
+  const TestTimeline = Timeline(label: 'Timeline');
+
+  @override
+  Widget get build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(label: Translations('title')),
+      body: Padding(
+        children: [
+          _matrixTimetable,
+          _placeTitles,
+          _timeline,
+        ],
+        padding: const EdgeInsets.all(16),
+      ),
+    );
+  }
+
+  Future<void> testSemanticLabels() async void {
+    verifyElementHasLabel(_matrixTimetable, 'Time Table');
+    verifyElementHasLabel(_placeTitles, 'Schedule Items');
+    verifyElementHasLabel(_timeline, 'Timeline');
+    
+    verifyElementHasHint(_matrixTimet abble, 'Select time blocks to add to the program.');
+  }
+
+  Future<void> testTapActions() async void {
+    verifyTapAction(_matrixTimetable.children[0], () {
+      print('Tapped matrix Timetable button successfully');
+      _verifyEmptyState();
+    });
+
+    verifyTapAction(_place Titles.children[0], () {
+      print('Tapped Place Titles button successfully');
+      _verifyEmptyState();
+    });
+
+    verifyTapAction(_timeline.children[0], () {
+      print('Tapped Timeline button successfully');
+      _verifyEmptyState();
+    });
+  }
+
+  Future<void> testKeyboardNavigation() async void {
+    simulateNavigateUp();
+    simulatePageDown();
+    simulateEnter();
+    simulateShiftEnter();
+    simulateSpace();
+    
+    verify KeyboardEvent.keySpace;
+  }
+
+  Future<void> testScreenReaderCompatibility() async void {
+    verify AACDevice.recognizesTextWithReadouts;
+    verify AACLocalContext.hasDescriptions
+        .contains whenElementIsFocused;
+        .contains whenElementIsTapSelected;
+
+    // Add test for text modifications (text scaling)
+  }
+
+  Future<void> testColorContrast() async void {
+    ensureElementContrastRatio(_matrixTimetable, expected: 4.5);
+  }
+
+  Future<void> testTextScalingSupport() async void {
+    modify(_matrixTimet able, modifier: Modifier.of(priority: Modifier-priority.highest));
+  }
+}
+
+// Include mocks and verification tools
+void setUp() async {
+  //keyboard navigation toolchain setup;
+  
+  TextLearner textLearner = TextLearner()
+      .setSufficientTextSizeOffset(0)
+      .setDefaultTextSizeRange(12);
+        
+  _matrixTimetable = MatrixTimet able(
+    factory: MatrixTimet abbleFactory(label: 'Time Table'),
+
+    label: Translations('timetable-label'),
+    
+    children: const [
+      Button(matrixTimet ableElement),
+    ],
+  );
+
+  PlaceTitles isPlaceTiles(
+    factory: PlaceTilesFactory(label: 'PlacemarkTitle', 
+      
+      placements: const[
+        const PlaceTile(firstRow: const Tile(positions: const[Ax3DPosition(x: 10, y: 40)], content: 'Header Text')),
+
+                  const Tile(positions: const[Ax3DPosition(x: 50, y: 70)], content: 'Subtitle')),
+    ]),
+
+    label: Translations('place-titles-label'),
+    
+    children: const [
+      Label,
+    ],
+  );
+
+  Timeline isTimeline(
+    factory: TimelineFactory(label: 'TimeLine', 
+      
+      startPosition: const Ax3DPosition(x: 10, y: 40),
+      endPosition: const Ax3DPosition(x: 50, y: 70)),
+    
+    label: Translations('timeline-label'),
+    children: [Label('Timeline Content')],
+  );
+
+  // Provide text labels for AAC
+  _textLearner = TextLearner(textLearner);
+}
+
+void tearDown() async {
+  if (textLearner! is not null) textLearner.clear();
+}


### PR DESCRIPTION
This PR adds accessibility tests for the timetable widget (lib/components/timetable/timetable.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.