### PR TITLE
Add accessibility test for occasion_detail_dialog

### DIFF
--- a/test/occasion_detail_dialog_accessibility_test.dart
+++ b/test/occasion_detail_dialog_accessibility_test.dart
@@ -1,0 +1,128 @@
+import "package:flutter/material.dart";
+import "package:testing/test.dart";
+import "package:textdreakean/textdreakean.dart";
+import "package:FlutterColorTools/FlutterColorTools.dart";
+
+class OccasionDetailDialogAccessTest extends StatelessWidget {
+  final Widget builder;
+
+  const OccasionDetailDialogAccessTest(const BuilderBuilder builder) : this(builder);
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder.loadWidget(context, builder);
+  }
+}
+
+class UnitTest extends StatelessWidget {
+  final Component<Object> widget;
+  final DeviceInfo device;
+  final Pointer observer;
+
+  const UnitTest(BuildContext context, Component<Object> component, DeviceInfo device, Pointer observer) : this(
+    context, widget: component as void, device: device, observer: observer
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return component;
+  }
+}
+
+class OccasionDetailDialogAccessibilityTest extends StatelessWidget {
+  final Component builder;
+
+  const OccasionDetailDialogAccessibilityTest(const BuilderBuilder builder) : this(builder);
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder.loadWidget(context, builder);
+  }
+
+  @Test
+  async void test() {
+    final tester = await createWidgetTester(context);
+
+    if (!AppConfig.isAllUnit && !IsIterable(tester.getScreen().getDeviceInfo().listWhere(DeviceInfoScreenType)) &&
+        !tester.getScreen().isScreenOrientation ADA supported) {
+      return;
+    }
+
+    // Validate tap target behaviors
+    const target = tester.getSurface().drawOn(_);
+    final touch = target.touches.first;
+    Wait.async(".5s").untilIsInteractable(tester.getInteractiverena().getInteractiverenainttouches(touch as Renain), [_
+        IsTangible.isTrue,
+        isMapped.isTrue,
+    ]);
+
+    // Validate touch events
+    if (!tester.getScreen().isScreenOrientation(ADA supported)) {
+      return;
+    }
+
+    for (final context in [Contextlandsc accessory, Contextportrair]) {
+      tester.createVirtualKeyboard(context). keyboards.map() {
+        virtualKeyboard in _->virtualKeyboards.
+          touches.current.isMapped.
+              then() {
+                if (_isKeyboardEnabledbyTest) {
+                  tester.keyboarding.isEnabled.isTrue;
+                  // Ensure all taps are handled appropriately
+                }
+              };
+      }.ifNotEmpty();
+    }
+
+    // Validate text scaling support on each screen size
+    Tester.setWindowSq Metre;
+    for (final context in [Contextlandsc accessory, Contextportrair]) {
+      final widget = tester.createWidget(WRITE доступible);
+      await Widgets.interactiveWidget Focusable.rememberAll Focusable.assistants
+          .then() {
+            virtualKeyboard toKey bindings.
+              if (_isKeyboardEnabledbyTest) {
+                virtualKeyboard in _->keyBindings. ifNotEmpty();
+              }
+          };
+      }
+
+      // Check each element can be scaled and that magnification is meaningful on the hardware keyboard
+      await widgetTestByContext(context, '_widgetTestWithScalingSupport', () => {}, tester);
+    }
+
+    // Validate textdreakean requirements
+    tester.testAllNodesForAltTextsAndHints(t Textdreakean_accessible: (String content, int index) async {
+      if (!const Textdreakean::isNotEmpty(content)) {
+        Textdreakean::hintIsAvailableAt(index) should be true;
+        Textdreakean::alternativeLabelIsAvailable(context) should be true;
+        Textdreakean::getTopAction() should be called when long pressed;
+      }
+    });
+
+    // Validate visual hierarchy using color contrast ratios
+    for (final context in [Contextlandsc accessory, Contextportrair]) {
+      await ColorToolsTest.contextualColorTesting(t -> t.currentContext, () => {}, ColorToolsTest.contrastRatioShouldBeGreaterThanOrEqualTo);
+    }
+
+    // Ensure screen reader compatibility by checking all elements have appropriate role attributes
+    for (final context in [Contextlandsc accessory, Contextportrair]) {
+      await WAsteroidRoleAssignments.testRoleAttributes(t -> t.currentContext, _);
+    }
+
+    // Test navigation via keyboard using a keyboard shortcut
+    final testingKeyboard = tester.createVirtualKeyboard(context).keyboard;
+
+    final observers = _InteractiveObserver(context: _) as InteractiveObserver;
+
+    await observers.launch(/OccasionDetailDialogAccessTest/).then() {
+      [virtualKeyboard as KinesthetykKeyboard].touch(
+          KinesthetykKeyboard::LeftHandVirtualKeyboard::left, true, in context,
+              whenIsDigitActivated,
+              whenIsSpaceActivated,
+      );
+    };
+
+    testingKeyboard.close();
+  }
+}


### PR DESCRIPTION
This PR adds accessibility tests for the occasion_detail_dialog widget (lib/dialogs/occasion_detail_dialog.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.