### PR TITLE
Add accessibility test for product_type_editor

### DIFF
--- a/test/product_type_editor_accessibility_test.dart
+++ b/test/product_type_editor_accessibility_test.dart
@@ -1,0 +1,156 @@
+/// **Description**
+This test verifies the accessibility features of the Products Type Editor widget,
+including semantic labels, keyboard navigation, screen reader compatibility,
+color contrast, and text scaling support.
+
+/// **Key Features Under Test**
+1. Semantic UI elements with proper HTML structure and labels
+2. Keyboard navigation using arrow keys and Enter
+3. Proper screen reader descriptions for all interactive widgets
+4. Consistent color contrast between text and background
+5. Text remain readable when scaled up
+
+import 'package:flutter/material.dart';
+import 'package:testWidgets/testWidgets.dart';
+
+void ProductTypeEditorTest() {
+  TestContainer container = TestContainer.create();
+  Widget tester = container.get('ProductTypeEditor');
+  
+  // Test cases class names (WP3, WCAG 2.1 AA)
+  @SuppressWarnings('WXCompat')
+  final AccessibilityTestCase@cwc(
+    testcaseID: 'ProductTypeEditorTest',
+    description: 'Product Type Editor widget accessibility tests',
+    requiredTrait = const_TRAIT,
+    testContainer = container
+  );
+
+  // Text areas must be usable without additional taps
+  QTest.addDescription('Product Type Name', 'name')
+
+  for (AccessibilityTestCase@cwc) in container.all(Types/accessibilityTestCase) {
+    context = @context;
+
+    if (!HtmlHelper.isHtmlEmptyOrNull(
+        widget.ptField.productType?.description)) {
+      DescriptionWithEdit.descriptionMustHave Semantic Hierarchy (
+          text: 'Description'
+      ');
+      QTest.TouchScreenDoubleTap(tester, context: context);
+      QTest EXPECT THAT audio.isPresent() BY(HasName('Description')).RE
+    }
+  }
+
+  // Verify keyboard navigation for all text areas with aria-labels
+  for (AccessibilityTestCase@cwc) in container.all(Types/accessibilityTestCase) {
+    context = @context;
+
+    keystroke = const KeyStroke(
+      key: 'Enter', modifierMask: keyDownMask,
+    );
+
+    QTest.TouchScreenDoubleTapBeforefter(
+        tester, 
+        before: QTest.Press(keystroke),
+        after: QTest.Press(keystroke),
+        context: context);
+  }
+
+  // Verify all elements have meaningful aria-labels
+  for (AccessibilityTestCase@cwc) in container.all(Types/accessibilityTestCase) {
+    @QCw
+    context = container.get('@context');
+
+    AudioTest AudioAnalyzer(
+      audio: null,
+      defaultContext: false,
+      customDescription:
+        'Check if element has proper name attribute',
+      waitForComplete: true,
+      repetitions: 1,
+    );
+
+    QTest.TouchScreen(doubleTapWithModifierMask: keyDownMask)
+      .before: Keystroke(key: 'Enter'),
+      .after: Keystroke(key: 'Enter'),
+      .in(context: context);
+  }
+
+  // Test Color Contrast Between Text Areas
+  for (AccessibilityTestCase@cwc) in container.all(Types/accessibilityTestCase) {
+    @QCw
+    context = container.get('@context');
+
+    ColorColorChecker colorChecker;
+
+    for (String elementName, Widget elementValue in [
+      'name Area', widget.ptField.nameValue,
+      'type Text Element', widget.ptField.typeValue,
+      'enabled Value', widget.ptField.enabledState,
+    ]) {
+      await colorChecker 开始;
+      QTest.TouchScreen(doubleTapWithModifierMask: keyDownMask)
+        .before: Keystroke(key: 'Enter'),
+        .after: Keystroke(key: 'Enter'),
+        .in(context: context);
+    }
+
+    doubleExpectedBeAQATestContext(colorChecker, context: context);
+  }
+
+  // Test scaled up text
+  @QCw
+  final testContainer = container;
+  final testerScaleWin = TestContainer.scale(testContainer);
+
+  for (AccessibilityTestCase@cwc) in container.all(Types/accessibilityTestCase) {
+    @QCw
+    final context = container.get('@context');
+
+    audioAnalyzer = AudioTest AudioAnalyzer(
+      defaultContext: false,
+      customDescription:
+        'Check if element has proper name attribute',
+      waitForComplete: true,
+      repetitions: 1,
+    );
+
+    QTest.TouchScreen(doubleTapWithModifierMask: keyDownMask)
+      .before: Keystroke(key: 'Enter'),
+      .after: Keystroke(key: 'Enter'),
+      .in(context: context);
+  }
+
+  scaledUpContext = context;
+}
+
+@QCw
+void ProductTypeEditorTest.run() {
+  // Test Descriptions Must Exist (WP3) and Have Semantic Hierarchy (WCAG 2.1 AA)
+  @QCwc(
+    testcaseID: 'DescriptionExists',
+    description: 'Product Type Name must be usable without additional taps',
+    reporterPathPrefix: 'testContainer.',
+  )
+
+  QTest.TouchScreen(doubleTapWithModifierMask: keyDownMask)
+    .before: Keystroke(key: 'Enter'),
+    .after: Keystroke(key: 'Enter');
+}
+
+@QCw
+void ProductTypeEditorTest.run() {
+ final requiredTrait = const_TRAIT;
+ for (AccessibilityTestCase@cwc) in container.all(Types/accessibilityTestCase) {
+   @QCwc(
+     testcaseID: 'DescriptionExists',
+     description: 'Product Type Name must be usable without additional taps',
+     reporterPathPrefix: 'testContainer.',
+   )
+
+   QTest.TouchScreen(doubleTapWithModifierMask: keyDownMask)
+     .before: Keystroke(key: 'Enter'),
+     .after: Keystroke(key: 'Enter');
+ }
+}


### PR DESCRIPTION
This PR adds accessibility tests for the product_type_editor widget (lib/pages/form/widgets_editor/product_type_editor.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.