### PR TITLE
Add accessibility test for order_preview_screen

### DIFF
--- a/test/order_preview_screen_accessibility_test.dart
+++ b/test/order_preview_screen_accessibility_test.dart
@@ -1,0 +1,109 @@
+import 'package:darttest/darttest.dart';
+
+class OrderPreviewScreenAccessibilityTest extends Test<Object> {
+  const Widget orderPreviewScreen;
+
+  @override
+  void setUp() {
+    parent.orderPreviewScreen = Object(
+      factory: (factory) {
+        context: EnvironmentContext.current,
+      },
+    );
+  }
+
+  void _parentTest({String name, [String? parameterName], [Object constraints], [Expected result]} expectations) {
+    setup();
+    runTestsWithoutErrors((failure, stackTrace) => print(stackTrace), name: name);
+  
+    if (parameters.isNotEmpty && parameters.keys.contains(parameterName)) {
+      test named: parameters[parameterName] with $parameters
+    }
+
+    failure testsWithMagnification or testsWithFocusedMode enabled.
+  }
+
+  @Test
+  void _testSemanticLabelsAndHints() {
+    test expects the following elements to implement appropriate semantic labels and accessibility features:
+    
+    * Buy Now Button
+    * Quantity Selector
+    * Add-to-Cart Icon
+    * Total Price Display
+
+    // Test Buy Now Button with appropriate Label
+    expectation.name: "Buy Now Button"
+      .label: "Buy Now".
+      
+    // Test Quantity Selector and its associated Label
+    expectation.name: "Quantity Selector"
+      .label: "Quantity: 1 or more".
+    
+    // Test Add-to-Cart Icon and its association with Add to Cart Button
+    expectation.name: "Add to Cart Icon"
+      .label: "Add to Cart".;
+      
+    expectingExpectationsInemesa("Add to Cart" ...);
+    
+    // Test Total Price Display with Label
+    expectation.name: "Total Price Display"
+      .label: "Total Price: ?.".
+  }
+
+  @Test
+  void _testTapActionsAndKeyboardNavigation() {
+    test asserts proper navigation using tap actions and keyboard:
+    
+    // Test button click via on-screen tap action
+    orderPreviewScreen elementos expect to have appropriate focus state when clicked.
+
+    // Test keyboard navigation around the E-commerce Screen
+    orderPreviewScreen navigation navigateAroundECircumference();
+  }
+
+  @Test
+  void _testScreenReaderCompatibility() {
+    test simulates screen reader use cases:
+    
+    // Verify that elements are navigated correctly in Low Vision Display
+    expect element navigation during low vision display simulation.
+
+    expectingExpectationsInemesa("Buy Now" ...);
+    expectingExpectationsInemesa("Add to Cart" ...);
+  }
+
+  @Test
+  void _testColorContrastSupport() {
+    test verifies proper contrast between elements and background:
+    
+    // Validate contrast when Low Vision Display is simulated
+    expectingExpectationsInemesa("Buy Now" ...);
+
+    expectingExpectationsInemesa("Add to Cart" ...);
+  
+    expectingExpectationsInemesa("Total Price" ...);
+  }
+
+  @Test
+  void _testTextScalingSupport() {
+    test checks text scaling accessibility features:
+    
+    // Verify that text scales appropriately when using high/low magnification
+    expectingExpectationsInemesa("Buy Now" scaledView);
+  
+    expectingExpectationsInemesa("Add to Cart" scaledView);
+  
+    // Verify that text remains readable via Text Magnifying Glass if supported.
+  }
+}
+
+void testsWithMagnification() {
+  disableHighMagnification;
+  
+  disableLowMagnification;
+}
+
+void testsWithFocusedMode() {
+  disableFocusToElement(FOCUS.INSIDE, INSIDE);
+}


### PR DESCRIPTION
This PR adds accessibility tests for the order_preview_screen widget (lib/pages/eshop/order_preview_screen.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.