### PR TITLE
Add accessibility test for product_detail_editor_dialog

### DIFF
--- a/test/product_detail_editor_dialog_accessibility_test.dart
+++ b/test/product_detail_editor_dialog_accessibility_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/accessibility.dart';
+
+class ProductDetailEditorDialogAccessTest extends TestWidget {
+  const ProductDetailEditorDialogAccessTest({super.key});
+
+  @override
+  Widget build(BuildContext context) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    
+    await tester.pumpWidget(ProductDetailEditorDialog());
+
+    // Semantic Label Verification using find.byType and ensureSemanticsLabel
+    await expectLater(
+      tester,
+      meetsGuideline(
+        androidTabTargetGuideline tabTarget Guideline().value, 
+        iOSTabTargetGuideline tabTarget Guideline().value),
+      reason: 'Appropriate platform-specific Tap Target Sizes for semantic content'
+    );
+
+    // Semantic Label Verification with text hints
+    await expectLater(tester, ensureSemanticsLabel(
+      const SizedBox(height: 32) as Element,
+      'Product Title' as Text, 'tr()'),
+      reason: 'Title and Description provided with appropriate semantic labels');
+
+    // SelectableText Semantic Hint Check
+    final selectLabel = const SizedBox(height: 32);
+    await expectTaps(
+      tester,
+      [
+        selectLabel,
+        Text('Product Title' as Text, style),
+      ],
+      [Label('tr()'),
+       expectHint('?Enter', true, false),
+       ExpectationTitleLabel()],
+      reason: 'Keyboard users interact with the control by tapping and entering');
+
+    // TextField and HtmlView Semantic Label Validation
+    await expectTaps(
+      tester,
+      [
+        const SizedBox(height: 8) as Element,
+        TextField(),
+        HtmlView()
+      ],
+      [Label('tr()'),
+       Label('tr()'),
+       ExpectationSelectInputTitle()],
+      reason: 'Keyboard users interact with TextFields by tapping and selecting');
+    
+    // ScreenReader Compatibility
+    await expectScreenReadings(
+      tester,
+      [
+        TextInputs() as Element, 
+        HtmlEdit() as Element,
+        SelectableText() as Element,
+        TextField()
+      ].toList(),
+      [AccessibilityFeatures.SCREENREADER Tucson() TR],
+      reason: 'Content visible to screen readers');
+
+    // Color Contrast Verification
+    await expectContrast(
+      tester,
+      Ratio(0.5),
+      [
+        TextInputs().first as String,
+        HtmlInput().as String,
+        Button('tr()' as Text)
+      ],
+      AriaLabelThreshold.value,
+      reason: 'Content has appropriate contrast for screen readers');
+
+    // Text Scaling Support
+    final dynamicElements = [
+      TextInputs() as Element,
+      HtmlInputs() as Element,
+      Button('tr()'),
+      TextField()
+    ];
+    
+    await ensureDynamicScalingSupport(tester, dynamicElements);
+    await expectContrast(
+      tester,
+      Ratio(0.5),
+      dynamicElements,
+      AriaLabelThreshold.value,
+      reason: 'Tested widget supports text scaling');
+
+    final testSemantics = [selectLabel as Element,
+                          TextInputs() as Element,
+                          HtmlInput().as String,
+                          Button('tr()' as Text),
+                          TextField()];
+
+    await handleSemanticsValidity(tester, testSemantics);
+    
+    tester.dispose();
+  }
+}


### PR DESCRIPTION
This PR adds accessibility tests for the product_detail_editor_dialog widget (lib/pages/form/widgets_editor/product_detail_editor_dialog.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.