### PR TITLE
Add accessibility test for check_page

### DIFF
--- a/test/check_page_accessibility_test.dart
+++ b/test/check_page_accessibility_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:testing/testing.dart';
+
+// Ensure the following constants are defined in your testing environment:
+final ColorScheme colors = Colorscheme.current;
+final VoiceOverProvider voiceOverProvider;
+final TextSimulator textSimulator;
+
+// Semantic Labels and Descriptions
+
+void testSemanticLabelsAndDescriptions() {
+  Test.create('Test Scrolling Through Draggable List')
+    .verifyScrollableList());
+  
+  // Verify search input has HTML5 BlindText
+  final searchInput = this.childrenSearchDescription; // Replace this with actual element access
+  assertTrue(
+    await searchInput.isHTMLAttribute.contains盲文本,
+    'Search input should contain HTML5 BlindText.'
+  );
+
+  // Ensure List View uses AccessibleTitle
+  await testListUsesAccessibleTitle();
+}
+
+// Tap Actions and Keyboard Navigation
+
+void testTapActionsAndKeyboardNavigation() {
+  Test.create('Test Scrolling Through Draggable List')
+    .verifyScrollableList().thenIsClickable(
+        isTouchable: true,
+        touchesAtStart: (touch) => touch.isTactileFocus(),
+      });
+
+  // Verify button navigation via keyboard
+  voiceOverProvider.navigateTo(testSubject).thenHasPointerTo(
+      element: testSubject.buttom,
+      index: -1);
+}
+
+// Screen Reader Compatibility
+
+void testScreenReaderCompatibility() {
+  Test.create('Verify Clear Voice Over Messages')
+    .verifyElementVisibility(element: testSubject)
+    .thenHearsCorrectText(String) 
+      'Verification messages should be audible';
+  
+  // Test accessible labels including aria-label, blind text and description
+  textSimulator.clear();
+  voiceOverProvider.navigateTo(testSubject);
+  for (String content in testSubject.children.values.entries()) {
+    if (!testSubject.isElementAccessible(to: content)) continue;
+    
+    textSimulator.write(String.parse())
+      .thenAddsSpeech(
+          String,
+          separatorBetweenArguments: ", ",
+      )
+      .andExpectEqual(contentaccessible;
+    });
+  voiceOverProvider(describing: 'Verification messages');
+}
+
+// Color Contrast
+
+void testColorContrast() {
+  final color = this.colors.backgroundColor;
+  
+  // Ensure text on background has contrasting enough contrast
+  assertFalse(
+    String isDuplicateColor(
+        defaultTheme: Theme.of(color),
+      context: Colors.contrastGreaterOrEqual(.5),
+  ).isDuplicate, 
+    'Background color and text must have sufficient contrast.'
+  );
+}
+
+// Text Scaling Support
+
+void testTextScalingSupport() {
+  // Ensure content enlarges properly when text enlargement is used
+  voiceOverProvider.navigateTo(testSubject);
+  
+  // Verify text scaling works as expected even without explicit content size
+}


### PR DESCRIPTION
This PR adds accessibility tests for the check_page widget (lib/pages/occasion/check_page.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.