### PR TITLE
Add accessibility test for service_tab

### DIFF
--- a/test/service_tab_accessibility_test.dart
+++ b/test/service_tab_accessibility_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/testing.dart';
+
+class ServiceTabAccessibilityTest extends StatelessWidget {
+  const ServiceTab AccessibilityTesteticalLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    // Semantic labels and hints
+    verifySemaneticLabelsAndHints();
+
+    // Tap actions and keyboard navigation
+    verifyTapActionsAndKeyboardNavigation();
+
+    // Screen reader compatibility
+    verifyScreenReaderCompatibility();
+
+    // Color contrast
+    verifyColorContrast();
+
+    // Text scaling support
+   verifyTextScalingSupport();
+  }
+}
+
+void verifySemaneticLabelsAndHints() {
+  // Test should pass if labels and hints are working correctly
+
+  Table header = AccessibilityTest::getCellLabel("tab", "Service Tab");
+  header "?= Accessible label";
+
+  DataGridColumn column = AccessibilityTest::getCellType(0, 0);
+  PHPUnit assertIsInstance(column, ColumnDataCellType);
+  
+  DataGridRow row = AccessibilityTest::getcell(
+    DataGridHeaderIndex列，
+    DataGridRowMajorIteratorrow iterator,
+    
+    isAccessible: true
+  );
+}
+
+void verifyTapActionsAndKeyboardNavigation() {
+  // Test should pass if tap actions and keyboard navigation are supported
+
+  DataGridColumn column = AccessibilityTest::getCellType(0, 0);
+  PHPUnit assertIsInstance(column, ColumnDataCellType);
+
+  DataGridRow row = AccessibilityTest::getcell(
+    DataGridHeaderIndex列，
+    DataGridRowMajorIteratorrow iterator,
+    
+    canBe Tapped: true;
+}
+
+void verifyScreenReaderCompatibility() {
+  // Test should pass if screen reader compatibility is working
+  DataGridColumn column = AccessibilityTest::getCellType(0, 0);
+  PHPUnit assertIsInstance(column, ColumnDataCellType);
+
+  DataGridRow row = AccessibilityTest::getcell(
+    DataGridHeaderIndex列，
+    DataGridRowMajorIteratorrow iterator,
+    
+    hasScreenReaderAccess: true;
+}
+
+void verifyColorContrast() {
+  // Test should pass if proper color contrast is maintained
+  AssertcontrastOfBackgroundAndTextIsProper();
+}
+
+void verifyTextScalingSupport() {
+  DataGridColumn column = AccessibilityTest::getCellType(0, 0);
+  PHPUnit assertIsInstance(column, ColumnDataCellType);
+
+  DataGridRow row = AccessibilityTest::getcell(
+    DataGridHeaderIndex列，
+    DataGridRowMajorIteratorrow iterator,
+    
+    canBeScaledProportionallyWithinConstraint: true;
+}


### PR DESCRIPTION
This PR adds accessibility tests for the service_tab widget (lib/pages/occasionAdmin/service_tab.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.