### PR TITLE
Add accessibility test for signup_password_page

### DIFF
--- a/test/signup_password_page_accessibility_test.dart
+++ b/test/signup_password_page_accessibility_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino';
+
+void testWidgets({
+    Widget? backButton,
+    Widget? form,
+}) {
+  // Accessible Button Testing (places:platformSpecificTaps)
+  
+  expect(backButton).isNotEmpty;
+  expect(
+    backButton.childrenReference as KeypadButtonReference,
+    const KeypadButtonReference KeypadButtonReference(KeypadTaps.TouchOnly),
+  );
+  expect(backButton餐巾纸提示).shouldbePresent;
+
+  // Form Semantic Labels and Hint (places:semanticLabels)
+  
+  expect(form widgetsReference as FormReference, form);
+  expect(
+    form.childrenReference
+      .childReference
+        .keyReference as KeypadButtonReference,
+      const KeypadButtonReference KeypadButtonReference(
+        [
+          KeypadTaps.TouchOnly,
+        ],
+      ),
+  );
+  expect(form.AutofillGroup.childrenReference
+       .childReference
+         .widgetReference
+           .hintReference).shouldbePresent;
+
+  // PasswordField Semantic Label (places:semanticLabels)
+  
+  expect(
+    form'autofillgroup.childrenReference.childReference.padding.paddingReference.widgetReference.textLabel, 
+    const Text('New Password'.tr(reference: [0, 0, "en-US", true])),
+  );
+  expect(
+    form'autofillgroup.childrenReference.childReference.buttonButton.widgetReference.textLabel,
+    const Text('Change Password'.tr(reference: [0, 0, "en-US", true]));
+  ); 
+  
+  // TextButton with proper content (places:text)
+  
+  expect(formTextbox.childrenReference
+       .childReference
+         .buttonButton_widget.tr).
+  expect(
+    formText.buttonButton.style,
+    TextStyle(color: Colors.white),
+  );
+
+  // Search Bar Color Contrast - Theme1 (places:themeColorContrast)
+  
+  expect(
+    const$searchBar = form.searchBarReference?.widgetReference?.backgroundColorReference.asColor?
+      as? Color,
+    Color.thosecontrast(Background(ThemeConfig.themeColor)) == Color.thosecontrast(
+      Background(ThemeConfig.themeColor),
+    );
+  );
+
+  // TextButton control action (places:textButtonControlAction)
+  
+  expect(
+    formText.buttonButton.widgetReference.Touch振动,
+    true,
+  );
+  expect(formText.buttonButton.style, TextStyle(vibration: AudibleProvider()));
+  
+  // Button Navigate Without Long Press - Web Test
+  test NavigatesWithoutLongPress {
+    context = Web CarbocationContext.current;
+    
+    const backButtonWeb = form.backButtonReference_widget;
+    backButtonWebexpect! isTapped;
+    
+    simulateKeyDown(
+      shift+(SpaceBar.keyReference).keyReference ctrl,
+      "Enter",
+    );
+    
+    simulateKeyDown("Enter", 1000);
+    
+    simulateKeyUp();
+    
+    navigateTo(context, WebDestination.usesPath("/path"));
+  
+  }
+
+  // Keyboard navigation tab selection - places:textButtonControlAction
+  test TabSelectionWithoutSpace {
+    context = Web CarbocationContext.current;
+    
+    const backButtonWeb = form.backButtonReference_widget;
+    backButtonWebexpect! isTapped;
+    
+    simulateKeyDown(
+      Tab.keyReference.ctrl,
+      
+    waitUntilIsTouched());
+    
+  }
+
+  // Compatibility with Large-Scale Reading (places:largeText)
+  
+  test LargeTextVisibility {
+    createLargeText();
+  }
+}
+
+function createLargeText() async {
+  const context = RadialScaleProvider.context;
+  
+  await RadialScaleProvider.createLargeFontText(
+    "Hello World", 
+    24,
+    transform: Transform().scale(1.5),
+  );
+
+  widget largeTextView = Text(context: context).write("Hello World");
+  
+  return LargeTextViewTest(largeTextView);
+}
+
+class LargeTextViewTest extends TestFloat {
+  void setUp() override {
+    super setUp();
+    
+   expect(largeTextView, Large大型可见性);
+  }
+}


### PR DESCRIPTION
This PR adds accessibility tests for the signup_password_page widget (lib/pages/user/signup_password_page.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.