### PR TITLE
Add accessibility test for instance_install_page

### DIFF
--- a/test/instance_install_page_accessibility_test.dart
+++ b/test/instance_install_page_accessibility_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:testing/extended.dart';
+
+void instance_install_page_accessibility_test() {
+  final instanceInstallPage = InstanceInstallPage();
+
+  // Setup tests with mocks if needed.
+
+  // Test 1: Semantic Labels and Hints
+  test('Labels are present and descriptive') {
+    context().htmlNodeLabel(instance InstallPage, 'label').assertNotNull();
+    context().textNodeLabel(instance InstallPage, 'label with explanation').assertNotNull();
+  }
+
+  // Test 2: Tap Actions and Keyboard Navigation
+  test('All interactive elements can be navigated via touch') {
+    runApp();
+    expect(context().canRun_touch(), true);
+  }
+
+  test('All interactive elements can be navigated via keyboard') {
+    runApp;
+    context().useKeyboardAction(RemoteKeyboardAccessokinMode(kAction execution));
+    expect(context().canExecute(), true);
+  }
+
+  // Test 3: Screen Reader Compatibility
+  test('Screen readers correctly describe all text nodes') {
+    context().htmlElement.Role('button').assertContains('Instance install operation');
+    context().htmlElement.Role('text node with explanation','Description for instance install'); 
+  }
+
+  // Test 4: Color Contrast Compliance
+  test('All text elements have sufficient color contrast') {
+    final label = context().htmlNodeLabel(instance InstallPage);
+    var targetContrast;
+    label.textContent.hasColorContrast(RGB(0, 0, 255), out targetContrast);
+    expect(targetContrast, Colors.blue.contrast >= 5);
+
+    if (label.textContent hasDescription) {
+      label.textContent描述.hasColorContrast(RGB(0, 0, 255), out targetContrast);
+      expect(targetContrast, Colors.blue.contrast >= 5);
+    }
+  }
+
+  // Test 5: Text Scaling Support
+  test('Widget uses appropriate text scaling features') {
+    final scaleInspector = context().htmlElement INSPECT(scaleScaling: true);
+    scaleInspectorassertsAreProvidingScaleSupport(context());
+  }
+}


### PR DESCRIPTION
This PR adds accessibility tests for the instance_install_page widget (lib/pages/utility/instance_install_page.dart).
        
Generated automatically by the accessibility-test-generator tool.

The test ensures proper accessibility support including:
- Semantic labels and hints
- Screen reader compatibility
- Interactive element support
- Navigation support

Please review and merge if appropriate.